### PR TITLE
remove config duplicate

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -31,37 +31,4 @@ service:
       receivers: [journald]
       processors: [batch]
       exporters: [awscloudwatchlogs]
-receivers:
-  journald:
-    # disabled for now: directory: /run/log/journal
-    units:
-      - sshd # Example unit, more can be added
-    priority: info
-
-processors:
-  resourcedetection/ec2:
-    detectors: ["ec2"]  
-  batch:
-
-exporters:
-  awscloudwatchlogs:
-    log_group_name: "testing-logs-emf"
-    log_stream_name: "testing-integrations-stream-emf"
-    # NOTE: optionally
-    raw_log: true
-    region: "us-east-1"
-    endpoint: "logs.us-east-1.amazonaws.com"
-    log_retention: 365
-    tags: { 'sampleKey': 'sampleValue'}
-
-extensions:
-  health_check:
-
-service:
-  extensions: [health_check]
-  pipelines:
-    logs:
-      receivers: [journald]
-      processors: [batch]
-      exporters: [awscloudwatchlogs]
 


### PR DESCRIPTION
This PR removes the duplicated configuration.

Looking at the current collector config, perhaps you would like to rename a few parameters or even make them configurable by the user?
https://github.com/redhatcloudx/observability-aws-cloudwatch/blob/f1663a25e5a3381ef92af2224a9c486f574732a0/config.yaml#L13-L22

**Update**

Perhaps the systemd units should also be configurable. wdyt?

https://github.com/redhatcloudx/observability-aws-cloudwatch/blob/f1663a25e5a3381ef92af2224a9c486f574732a0/config.yaml#L1-L6
---
cc @miyunari 