### PR TITLE
fix: otel binary path

### DIFF
--- a/opentelemetry-collector-cloudwatch-config.service
+++ b/opentelemetry-collector-cloudwatch-config.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/bin/otel-base --config /etc/observability-aws/config.yaml
+ExecStart=/usr/bin/opentelemetry-collector --config /etc/observability-aws/config.yaml
 Restart=on-failure
 RestartSec=30
 


### PR DESCRIPTION
The binary path has been invalid:
```
Apr 02 09:02:06 ip-172-31-94-181.ec2.internal systemd[6033]: opentelemetry-collector-cloudwatch-config.service: Failed at step EXEC spawning /bin/otel-base: No such file or directory
Apr 02 09:02:06 ip-172-31-94-181.ec2.internal systemd[1]: Started Observability AWS Cloudwatch Integration.
Apr 02 09:02:06 ip-172-31-94-181.ec2.internal systemd[1]: opentelemetry-collector-cloudwatch-config.service: Main process exited, code=exited, status=203/EXEC
Apr 02 09:02:06 ip-172-31-94-181.ec2.internal systemd[1]: opentelemetry-collector-cloudwatch-config.service: Failed with result 'exit-code'.
```

See:
https://github.com/os-observability/redhat-opentelemetry-collector/blob/15f553e5ec93fe04489cca785c93018b79b0f501/collector.spec.in#L35

cc @miyunari 