### PR TITLE
fix: config.yaml path

### DIFF
--- a/opentelemetry-collector-cloudwatch-config.service
+++ b/opentelemetry-collector-cloudwatch-config.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/opentelemetry-collector --config /etc/observability-aws/config.yaml
+ExecStart=/usr/bin/opentelemetry-collector --config /etc/opentelemetry-collector-cloudwatch-config/config.yaml
 Restart=on-failure
 RestartSec=30
 


### PR DESCRIPTION
Add the correct path to the otel config.yaml as distributed by the opentelemetry-collector-cloudwatch-config rpm.